### PR TITLE
Expose Sampling llama.cpp implementation

### DIFF
--- a/llama.xcodeproj/project.pbxproj
+++ b/llama.xcodeproj/project.pbxproj
@@ -8,6 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		972079C42AFAACEF008A9E53 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 972079C32AFAACEF008A9E53 /* Accelerate.framework */; };
+		9789E9FC2B0D49BA00EB6AD2 /* sampling.h in Sources */ = {isa = PBXBuildFile; fileRef = 97FFE3072B056DD100B12DEC /* sampling.h */; };
+		9789E9FD2B0D49BD00EB6AD2 /* grammar-parser.h in Sources */ = {isa = PBXBuildFile; fileRef = 97FFE3062B056DD100B12DEC /* grammar-parser.h */; };
+		9789E9FE2B0D49BF00EB6AD2 /* log.h in Sources */ = {isa = PBXBuildFile; fileRef = 97FFE3052B056DD100B12DEC /* log.h */; };
 		97F217F92B044111008B81FE /* common.h in Headers */ = {isa = PBXBuildFile; fileRef = 97F217F82B044111008B81FE /* common.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		97F217FB2B044120008B81FE /* common.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 97F217FA2B044120008B81FE /* common.cpp */; };
 		97F217FC2B04413F008B81FE /* common.h in Sources */ = {isa = PBXBuildFile; fileRef = 97F217F82B044111008B81FE /* common.h */; };
@@ -22,6 +25,8 @@
 		97F996DE2AFB2A3F00194A6F /* ggml.c in Sources */ = {isa = PBXBuildFile; fileRef = 97F996DD2AFB2A3F00194A6F /* ggml.c */; };
 		97F996DF2AFB2AE100194A6F /* ggml.h in Sources */ = {isa = PBXBuildFile; fileRef = 97F996D12AFB29C700194A6F /* ggml.h */; };
 		97F996E02AFB2AE100194A6F /* llama.h in Sources */ = {isa = PBXBuildFile; fileRef = 97F996DB2AFB29F900194A6F /* llama.h */; };
+		97FAF1B32B0D4DA900E23209 /* grammar-parser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 97FAF1B12B0D4DA900E23209 /* grammar-parser.cpp */; };
+		97FAF1B42B0D4DA900E23209 /* sampling.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 97FAF1B22B0D4DA900E23209 /* sampling.cpp */; };
 		97FFE3082B056DD100B12DEC /* log.h in Headers */ = {isa = PBXBuildFile; fileRef = 97FFE3052B056DD100B12DEC /* log.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		97FFE3092B056DD100B12DEC /* grammar-parser.h in Headers */ = {isa = PBXBuildFile; fileRef = 97FFE3062B056DD100B12DEC /* grammar-parser.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		97FFE30A2B056DD100B12DEC /* sampling.h in Headers */ = {isa = PBXBuildFile; fileRef = 97FFE3072B056DD100B12DEC /* sampling.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -42,6 +47,8 @@
 		97F996D32AFB29C700194A6F /* llama.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = llama.cpp; sourceTree = "<group>"; };
 		97F996DB2AFB29F900194A6F /* llama.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = llama.h; sourceTree = "<group>"; };
 		97F996DD2AFB2A3F00194A6F /* ggml.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ggml.c; sourceTree = "<group>"; };
+		97FAF1B12B0D4DA900E23209 /* grammar-parser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "grammar-parser.cpp"; path = "common/grammar-parser.cpp"; sourceTree = "<group>"; };
+		97FAF1B22B0D4DA900E23209 /* sampling.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sampling.cpp; path = common/sampling.cpp; sourceTree = "<group>"; };
 		97FFE3052B056DD100B12DEC /* log.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = log.h; path = common/log.h; sourceTree = "<group>"; };
 		97FFE3062B056DD100B12DEC /* grammar-parser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "grammar-parser.h"; path = "common/grammar-parser.h"; sourceTree = "<group>"; };
 		97FFE3072B056DD100B12DEC /* sampling.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sampling.h; path = common/sampling.h; sourceTree = "<group>"; };
@@ -62,6 +69,8 @@
 		9720799C2AFAA818008A9E53 = {
 			isa = PBXGroup;
 			children = (
+				97FAF1B12B0D4DA900E23209 /* grammar-parser.cpp */,
+				97FAF1B22B0D4DA900E23209 /* sampling.cpp */,
 				979D479D2B081F3E00EF8149 /* llama-module.modulemap */,
 				97FFE3062B056DD100B12DEC /* grammar-parser.h */,
 				97FFE3052B056DD100B12DEC /* log.h */,
@@ -183,16 +192,21 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				97F217FC2B04413F008B81FE /* common.h in Sources */,
-				97F996DF2AFB2AE100194A6F /* ggml.h in Sources */,
 				97F996E02AFB2AE100194A6F /* llama.h in Sources */,
-				97F996D52AFB29C700194A6F /* ggml-quants.c in Sources */,
 				97F996DA2AFB29C700194A6F /* llama.cpp in Sources */,
-				97F217FB2B044120008B81FE /* common.cpp in Sources */,
-				97F996D92AFB29C700194A6F /* ggml-alloc.c in Sources */,
-				97F996D62AFB29C700194A6F /* ggml-metal.m in Sources */,
+				97F996DF2AFB2AE100194A6F /* ggml.h in Sources */,
 				97F996DE2AFB2A3F00194A6F /* ggml.c in Sources */,
+				97F996D92AFB29C700194A6F /* ggml-alloc.c in Sources */,
 				97F996D72AFB29C700194A6F /* ggml-backend.c in Sources */,
+				97F996D52AFB29C700194A6F /* ggml-quants.c in Sources */,
+				97F996D62AFB29C700194A6F /* ggml-metal.m in Sources */,
+				97F217FC2B04413F008B81FE /* common.h in Sources */,
+				97F217FB2B044120008B81FE /* common.cpp in Sources */,
+				9789E9FC2B0D49BA00EB6AD2 /* sampling.h in Sources */,
+				97FAF1B42B0D4DA900E23209 /* sampling.cpp in Sources */,
+				9789E9FD2B0D49BD00EB6AD2 /* grammar-parser.h in Sources */,
+				97FAF1B32B0D4DA900E23209 /* grammar-parser.cpp in Sources */,
+				9789E9FE2B0D49BF00EB6AD2 /* log.h in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
# Expose Sampling llama.cpp implementation

## :recycle: Current situation & Problem
As of now, functions from the `sampling.h` header couldn't be called from outside entities as only the header file was included and exposed, not the underlying C++ implementation file.


## :gear: Release Notes 
- Expose sampling functionality of llama.cpp to enable convenient sampling


## :books: Documentation
--


## :white_check_mark: Testing
Locally tested


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
